### PR TITLE
removeAt(0), removeAll, retainAll

### DIFF
--- a/src/org/jetbrains/kotlin/collections/ArrayList.kt
+++ b/src/org/jetbrains/kotlin/collections/ArrayList.kt
@@ -15,7 +15,10 @@ class ArrayList<E> private constructor(
 
     override val size : Int
         get() = length
-    
+
+    val capacity: Int
+        get() = a.size
+
     override fun isEmpty(): Boolean = length == 0
 
     override fun get(index: Int): E {
@@ -100,15 +103,29 @@ class ArrayList<E> private constructor(
 
     override fun clear() {
         array.resetRange(offset, offset + length)
+        offset = 0
         length = 0
     }
 
     override fun removeAt(index: Int): E {
         checkIndex(index)
-        val old = array[offset + index]
-        array.copyRange(offset + index + 1, offset + length, offset + index)
-        array.resetAt(offset + length - 1)
+
+        val arrayIndex = offset + index
+        val old = array[arrayIndex]
+
+        if (index == 0) {
+            array.resetAt(arrayIndex)
+            offset++
+        } else {
+            array.copyRange(arrayIndex + 1, offet + length, arrayIndex)
+            array.resetAt(offset + length - 1)
+        }
+
         length--
+        if (length == 0) {
+            offset = 0
+        }
+
         return old
     }
 
@@ -180,6 +197,12 @@ class ArrayList<E> private constructor(
 
     private fun ensureExtraCapacity(n: Int = 1) {
         ensureCapacity(length + n)
+        if (a.size - (ofs + length) < n) {
+            // roll array
+            a.copyRange(ofs, ofs + length, 0)
+            a.resetRange(len, ofs + length)
+            ofs = 0
+        }
     }
 
     private fun insertAt(index: Int, n: Int = 1) {

--- a/src/org/jetbrains/kotlin/collections/ArrayList.kt
+++ b/src/org/jetbrains/kotlin/collections/ArrayList.kt
@@ -110,7 +110,7 @@ class ArrayList<E> private constructor(
     override fun removeAt(index: Int): E {
         checkIndex(index)
 
-        val old = a[offset + index]
+        val old = array[offset + index]
         removeRange(index, index + 1)
 
         return old
@@ -118,17 +118,17 @@ class ArrayList<E> private constructor(
 
     private fun removeRange(fromIndex: Int, toIndex: Int): Int {
         checkIndex(fromIndex)
-        require(toIndex in itrIndices())
+        checkItrIndex(toIndex)
         require(fromIndex <= toIndex)
 
         val arrayIndex = offset + fromIndex
         val rangeLength = toIndex - fromIndex
 
         if (fromIndex == 0) {
-            a.resetRange(arrayIndex, arrayIndex + rangeLength)
+            array.resetRange(arrayIndex, arrayIndex + rangeLength)
             offset += rangeLength
         } else {
-            array.copyRange(arrayIndex + rangeLength, offet + length, arrayIndex)
+            array.copyRange(arrayIndex + rangeLength, offset + length, arrayIndex)
             array.resetAt(offset + length - rangeLength)
         }
 
@@ -162,8 +162,8 @@ class ArrayList<E> private constructor(
         var removeRangeStart = -1
         var index = 0
 
-        while (index < len) {
-            if (predicate(a[ofs + index])) {
+        while (index < length) {
+            if (predicate(array[offset + index])) {
                 if (removeRangeStart == -1) {
                     removeRangeStart = index
                 }
@@ -180,7 +180,7 @@ class ArrayList<E> private constructor(
 
         if (removeRangeStart != -1) {
             changed = true
-            removeRange(removeRangeStart, len)
+            removeRange(removeRangeStart, length)
         }
 
         return changed
@@ -235,11 +235,11 @@ class ArrayList<E> private constructor(
 
     private fun ensureExtraCapacity(n: Int = 1) {
         ensureCapacity(length + n)
-        if (a.size - (ofs + length) < n) {
+        if (array.size - (offset + length) < n) {
             // roll array
-            a.copyRange(ofs, ofs + length, 0)
-            a.resetRange(len, ofs + length)
-            ofs = 0
+            array.copyRange(offset, offset + length, 0)
+            array.resetRange(length, offset + length)
+            offset = 0
         }
     }
 

--- a/test/org/jetbrains/kotlin/collections/ArrayListTest.kt
+++ b/test/org/jetbrains/kotlin/collections/ArrayListTest.kt
@@ -104,6 +104,43 @@ class ArrayListTest {
         assertEquals(listOf(1, 3), a.toList())
     }
 
+    @Test fun testRemoveAll() {
+        val a = ArrayList(listOf(1, 2, 3))
+
+        assertFalse(a.removeAll(5..10))
+        assertEquals(3, a.size)
+
+        assertTrue(a.removeAll(1..10))
+        assertEquals(0, a.size)
+    }
+
+    @Test fun testRemoveAll2() {
+        val a = ArrayList(listOf(1, 2, 3))
+
+        assertFalse(a.removeAll(5..10))
+        assertEquals(3, a.size)
+
+        assertTrue(a.removeAll(1..2))
+        assertEquals(1, a.size)
+        assertEquals(listOf(3), a.toList())
+    }
+
+    @Test fun testRemoveAll3() {
+        val a = ArrayList(listOf(1, 2, 3))
+
+        assertTrue(a.removeAll(2..3))
+        assertEquals(1, a.size)
+        assertEquals(listOf(1), a.toList())
+    }
+
+    @Test fun testRemoveAll4() {
+        val a = ArrayList((1..10).toList())
+
+        assertTrue(a.removeAll((2..3) + (6..8)))
+        assertEquals(5, a.size)
+        assertEquals(listOf(1, 4, 5, 9, 10), a.toList())
+    }
+
     @Test
     fun testEquals() {
         val a = ArrayList(listOf(1, 2, 3))

--- a/test/org/jetbrains/kotlin/collections/ArrayListTest.kt
+++ b/test/org/jetbrains/kotlin/collections/ArrayListTest.kt
@@ -63,6 +63,47 @@ class ArrayListTest {
         assertEquals(3, a[1])
     }
 
+    @Test fun testRemoveAtFromEnd() {
+        val a = ArrayList(listOf(1, 2, 3))
+
+        assertEquals(3, a.size)
+        a.removeAt(2)
+        assertEquals(2, a.size)
+        assertEquals(listOf(1, 2), a.toList())
+
+        a.removeAt(1)
+        assertEquals(1, a.size)
+        assertEquals(listOf(1), a.toList())
+
+        a.removeAt(0)
+        assertEquals(0, a.size)
+        assertEquals(listOf<Int>(), a.toList())
+    }
+
+    @Test fun testRemoveAtStart() {
+        val a = ArrayList<Int>(5)
+        a.addAll(listOf(1, 2, 3))
+
+        assertEquals(3, a.size)
+        a.removeAt(0)
+        assertEquals(2, a.size)
+        assertEquals(listOf(2, 3), a.toList())
+
+        a.addAll(1..3)
+        assertEquals(5, a.size)
+        assertEquals(listOf(2, 3, 1, 2, 3), a.toList())
+        assertEquals(5, a.capacity) // no array growth
+    }
+
+    @Test fun testRemoveInTheMiddle() {
+        val a = ArrayList(listOf(1, 2, 3))
+
+        assertEquals(3, a.size)
+        a.removeAt(1)
+        assertEquals(2, a.size)
+        assertEquals(listOf(1, 3), a.toList())
+    }
+
     @Test
     fun testEquals() {
         val a = ArrayList(listOf(1, 2, 3))


### PR DESCRIPTION
- fast removal from the beginning (an array is rolled only when required)
- removeAll and retainAll both remove ranges batch by batch instead of remove single elements
- removeAll should remove all duplicates (?)
